### PR TITLE
chore(GraphQL): use url instead of store-id for GraphQLClient

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,6 +1,6 @@
 import { GraphQLClient } from "graphql-request";
 import { getSdk } from "@/__generated__/sdk";
-const client = new GraphQLClient("[your_store_name]", {
+const client = new GraphQLClient("https://[your_store_name].swell.store/graphql", {
   headers: {
     Authorization: "[your_public_key]",
   },


### PR DESCRIPTION
The `new GraphQLClient` functions needs an `url` as first parameter, not only the store-id.

This partially fixes #1 